### PR TITLE
Replace React app with minimal static personal site

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 </head>
 <body>
   <h1>Jorge Vizcayno</h1>
-  <p class="tagline">Founder &amp; Engineer. Building for Latin America.</p>
+  <p class="tagline">Founder &amp; Engineer. Building from CDMX / NYC.</p>
 
   <p>
     I co-founded <a href="https://techcrunch.com/2022/09/12/alima-latin-america-perishable-food-supply-chain/" target="_blank" rel="noopener">Alima</a> (YC W22), a B2B marketplace for perishable food supply chains in Latin America. I am currently a Team Lead at <a href="https://techcrunch.com/2024/05/13/pepper-iconiq-startup-foodservice-ecommerce-30m/" target="_blank" rel="noopener">Pepper</a>, a foodservice e-commerce platform backed by ICONIQ.
@@ -100,7 +100,7 @@
     <span>&middot;</span>
     <a href="https://linkedin.com/in/jorgeviz" target="_blank" rel="noopener">linkedin</a>
     <span>&middot;</span>
-    <a href="https://twitter.com/jorgevizg" target="_blank" rel="noopener">@jorgevizg</a>
+    <a href="https://x.com/jorgeviz_" target="_blank" rel="noopener">@jorgeviz_</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Replaces the entire React app with a single `index.html` static site.

## Changes
- Deletes all source files, build artifacts, and tooling (`src/`, `public/`, `docs/`, `package.json`, etc.)
- Single `index.html` with embedded CSS — no frameworks, no build tools, no JavaScript
- Lora serif font via Google Fonts
- Links to Alima and Pepper TechCrunch articles
- GitHub, LinkedIn, and X (`@jorgeviz_`) links

## Deploy notes
After merging, set GitHub Pages source to **master branch → / (root)** in repo Settings → Pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_012xZvm2VaAPHM5ag9HPb6Rg)_